### PR TITLE
Filter docs

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -58,6 +58,10 @@ export default defineConfig({
                         text: "Mutate",
                         link: "/dicom-capacitor/filters/mutate",
                       },
+                      {
+                        text: "Sort",
+                        link: "/dicom-capacitor/filters/sort",
+                      }
                     ],
                   },
                 ],

--- a/docs/dicom-capacitor/filters/mutate.md
+++ b/docs/dicom-capacitor/filters/mutate.md
@@ -2,6 +2,84 @@
 
 The mutate filter lets you apply mutations to incoming DICOM data.  Mutations are defined in a `mutations.yml` file, and are applied to incoming DICOM data before it is sent to destinations.
 
+In order to enable the mutate filter, you must add the `mutate` filter to the `filters` section of your `config.yml` file.
+```yaml
+# config.yml
+filters:
+  - mutate
+```
+or, simply:
+
+```yaml
+# config.yml
+filters: mutate
+```
+## Mutate Components
+
+Each mutation component is defined as follows:
+
+- `Conditions`: (Optional) A list of conditions that must be met for this mutation to apply.
+- `Actions`: (Required) A list of actions to take when this mutation applies.
+- `Affects`: (Optional) A list of DICOM dataset contexts that this mutation affects:
+  - worklist_query
+  - worklist_result
+  - qr_find_query
+  - qr_find_result
+
+### Conditions
+
+The `Conditions` field is an optional list of conditions that must be met for this mutation to apply.  Conditions are a shared concept between the `route` and `mutate` filters, and are described in their own [Conditions](./conditions) page.
+
+### Actions
+
+The actions field is required, and must be a list of one or more actions to take when each mutation applies.
+
+Each action component is defined as follows:
+
+- `Description`: A description of the action that will appear in the logs.
+
+- `Type`: The type of action to take. Possible values are:
+
+  - `add_or_update`: Adds new tags or updates existing ones based on pattern matching
+  
+  - `anonymize`: Anonymizes patient
+  
+  - `exclude_result`: Excludes the current dataset from processing
+  
+  - `query`: Performs a worklist query and merges results into the dataset
+  
+  - `remove`: Removes specified tags from the dataset
+  
+  - `stamp`: Adds visual stamps to image data
+
+- `SourceTag`: (Optional, `add_or_update` action only) DICOM tag to match
+
+- `DestinationTag`: (Required for `add_or_update`, `remove` and `stamp` actions) DICOM tag to modify
+
+- `DestinationValue`: (Required for `add_or_update`, `remove` and `stamp` actions) New value
+
+- `Node`: (Required for `query` type) The worklist node to query for additional data
+
+- `Request`: (Required for `query` type) List of source/destination pairs defining query parameters:
+  ```yaml
+  Request:
+    - SourceTag: 0010,0020
+      DestinationTag: 0010,0020
+  ```
+
+- `Response`: (Required for `query` type) List of source/destination pairs defining result merging:
+  ```yaml
+  Response:
+    - SourceTag: 0032,1060
+      DestinationTag: 0008,1030
+  ```
+
+- `OnError`: (Optional - `add_or_remove` and `query` actions only) Error handling behavior:
+  - `skip_action`: Skip current action
+  - `end_mutation`: Stop mutation chain
+  - `retry`: Retry operation
+  - `fail`: Fail processing
+
 ## Mutations Example
 
 An example `mutations.yml` file is shown below:
@@ -41,16 +119,3 @@ An example `mutations.yml` file is shown below:
   Actions:
     - Type: exclude_result
 ```
-
-## Mutate Components
-
-Each mutation component is defined as follows:
-
-- `Description`:  A description of the mutation that will appear in the logs.
-- `Conditions`: (Optional) A list of conditions that must be met for this mutation to apply.
-- `Actions`: (Required) A list of actions to take when this mutation applies.
-- `Affects`: (Optional) A list of DICOM dataset contexts that this mutation affects.
-
-### Conditions
-
-The `Conditions` field is an optional list of conditions that must be met for this mutation to apply.  Conditions are a shared concept between the `route` and `mutate` filters, and are described in their own [Conditions](./conditions) page.

--- a/docs/dicom-capacitor/filters/sort.md
+++ b/docs/dicom-capacitor/filters/sort.md
@@ -1,0 +1,71 @@
+# Sort Filter
+
+The sort filter provides precise control over DICOM instance ordering within series, supporting both integer and string-based sorting. Sorts are defined in a `sortings.yml` file, and are applied to incoming DICOM data before it is sent to destinations.
+
+In order to enable the sort filter, you must add the `sort` filter to the `filters` section of your `config.yml` file.
+
+```yaml
+# config.yml
+filters:
+  - sort
+```
+or, simply:
+
+```yaml
+# config.yml
+filters: sort
+```
+## Sort Components
+Each sort component is defined as follows:
+
+- `AE Titles`: List of DICOM nodes where sorting applies.
+- `Actions`: (Required) A list of actions to take when this sort applies.
+- `Affects`: (Optional) A list of DICOM dataset contexts that this mutation affects. 
+  - worklist_query
+  - worklist_result
+  - qr_find_query
+  - qr_find_result
+
+
+## Sort Example
+
+An example `sortings.yml` file is shown below:
+
+```yaml
+# Basic numeric instance sorting
+- AeTitles:
+    - offis
+  Actions:
+    - Description: "Sort by SeriesNumber"
+      Type: sort
+      SortTag: 0020,0011
+      SortType: integer
+      SortDirection: asc
+
+# Multi-level MR sorting
+- AeTitles:
+    - mr_scanner
+  Actions:
+    - Description: "Sort by acquisition"
+      Type: sort
+      SortTag: 0020,0012
+      SortType: integer
+      SortDirection: asc
+    - Description: "Sort by instance"
+      Type: sort
+      SortTag: 0020,0013
+      SortType: integer
+      SortDirection: asc
+```
+
+### Actions
+
+The actions field is required, and must be a list of one or more actions to take when each sort applies.
+
+Each action component is defined as follows:
+
+- `Description`:  A description of the action that will appear in the logs.
+- `Type`:  The type of action to take. This must be `sort`.
+- `SortTag`: (Required) The DICOM tag to sort by.
+- `SortType`: (Required) The type of data to sort. This must be either `integer` or `string`.
+- `SortDirection`: (Required) The direction to sort. This must be either `asc` or `desc`.

--- a/docs/dicom-capacitor/filters/sort.md
+++ b/docs/dicom-capacitor/filters/sort.md
@@ -26,8 +26,19 @@ Each sort component is defined as follows:
   - qr_find_query
   - qr_find_result
 
+### Actions
 
-## Sort Example
+The actions field is required, and must be a list of one or more actions to take when each sort applies.
+
+Each action component is defined as follows:
+
+- `Description`:  A description of the action that will appear in the logs.
+- `Type`:  The type of action to take. This must be `sort`.
+- `SortTag`: (Required) The DICOM tag to sort by.
+- `SortType`: (Required) The type of data to sort. This must be either `integer` or `string`.
+- `SortDirection`: (Required) The direction to sort. This must be either `asc` or `desc`.
+
+## Sorting Examples
 
 An example `sortings.yml` file is shown below:
 
@@ -57,15 +68,3 @@ An example `sortings.yml` file is shown below:
       SortType: integer
       SortDirection: asc
 ```
-
-### Actions
-
-The actions field is required, and must be a list of one or more actions to take when each sort applies.
-
-Each action component is defined as follows:
-
-- `Description`:  A description of the action that will appear in the logs.
-- `Type`:  The type of action to take. This must be `sort`.
-- `SortTag`: (Required) The DICOM tag to sort by.
-- `SortType`: (Required) The type of data to sort. This must be either `integer` or `string`.
-- `SortDirection`: (Required) The direction to sort. This must be either `asc` or `desc`.


### PR DESCRIPTION
Documentation updates:

* [`docs/.vitepress/config.mjs`](diffhunk://#diff-e0e81172f9f8a894faac0cb1a605113750ed24b4618a8cecdc680f253e1c1762R61-R64): Added a link to the new "Sort" filter section in the navigation menu.

* `docs/dicom-capacitor/filters/mutate.md`: Expanded the documentation to include detailed instructions on enabling the filter, defining mutation components, and examples of mutation configurations.

* [`docs/dicom-capacitor/filters/route.md`](diffhunk://#diff-8027085b3f630123aa2002e7af229377798b1e7af4caf62edcfacd47a44426bbL3-R4): Matched the style of the route filter documentaation to the mutate and sort filters. Fixed typos.

* [`docs/dicom-capacitor/filters/sort.md`](diffhunk://#diff-3641ea465cf1ea8e8fca25e0442cac42834da9c0a0e4c2e4a7fab1919d46d68dR1-R70): Added a new section detailing the sort filter, including how to enable it, define sort components, and examples of sorting configurations.