### PR TITLE
Command-line-docs

### DIFF
--- a/.github/workflows/gpt-auto-pr-description.yml
+++ b/.github/workflows/gpt-auto-pr-description.yml
@@ -1,0 +1,17 @@
+name: Draft PR Description
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, edited]
+
+jobs:
+  change-description:
+    runs-on: ubuntu-latest
+    name: Draft PR Description
+    steps:
+      - name: Add Draft PR description
+        uses: fluxinc/gpt-auto-pr-description-action@master
+        with:
+          trigger-word: "ai-draft"
+          github-token: ${{ secrets.TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+          openai-token: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/gpt-auto-pr-description.yml
+++ b/.github/workflows/gpt-auto-pr-description.yml
@@ -12,6 +12,6 @@ jobs:
         uses: fluxinc/gpt-auto-pr-description-action@master
         with:
           trigger-word: "ai-draft"
-          github-token: ${{ secrets.TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ github.event.pull_request.number }}
           openai-token: ${{ secrets.OPENAI_API_KEY }}

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -29,7 +29,7 @@ export default defineConfig({
               { text: "Overview", link: "/dicom-capacitor/overview" },
               { text: "Installation", link: "/dicom-capacitor/installation" },
               { text: "Docker", link: "/dicom-capacitor/docker" },
-              { text: "Command Line", link: "/dicom-capacitor/command-line" },
+              { text: "Command Line Options", link: "/dicom-capacitor/command-line" },
               {
                 text: "Configuration",
                 link: "/dicom-capacitor/configuration",

--- a/docs/dicom-capacitor/command-line.md
+++ b/docs/dicom-capacitor/command-line.md
@@ -1,12 +1,52 @@
 # Command Line Options
 
-Capacitor accepts the following command line options:
+## Basic Syntax
+```bash
+DICOMCapacitorService.exe [options]
+```
 
+## Installation Options
+- `--install`, `-i`: Install as Windows service
+- `--uninstall`, `-u`: Remove Windows service
+- `--restart-service [PID]`, `-rs [PID]`: Restart service using process ID
 - `--path`: Sets the path to the configuration files (default: `%ProgramData%\Flux\DICOM Capacitor\`)
+
+## Configuration Options
+- `--activation-code [CODE]`, `-a [CODE]`: Set product activation code
 - `--no-storage-scu`: Disables the Storage SCU
 - `--no-worklist-scu`: Disables the Worklist SCU
 - `--no-prepare`: Disables preparation, which is the process of preparing files for storage
 - `--save-config`: Saves the current settings to the `config.yml` file.  Be careful with this option, as it
   will overwrite the existing `config.yml` file.
+
+## Development Options
 - `--mutate`: Applies the mutations defined in `mutations.yml`. This option requires a list of
   DICOM files to be provided, and is intended for testing purposes.
+- `--clear-secure-logs [PASSWORD]`: Clear secure audit logs
+- `--quit`, `-q`: Exit after running commands
+
+## Examples
+
+### Basic Installation
+```bash
+DICOMCapacitorService.exe --install
+```
+
+### Custom Installation
+```bash
+DICOMCapacitorService.exe --install --path "D:\DICOM" --no-storage-scu --save-config
+```
+
+### Set Activation
+```bash
+DICOMCapacitorService.exe --activation-code "XXXX-XXXX-XXXX" --save-config
+```
+
+### Development Usage
+```bash
+# Process single file
+DICOMCapacitorService.exe --mutate [SRC_AE] [DST_AE] [IN_DCM_FILE] [OUT_DCM_FILE]
+
+# Clear logs
+DICOMCapacitorService.exe --clear-secure-logs "password"
+```

--- a/docs/dicom-capacitor/command-line.md
+++ b/docs/dicom-capacitor/command-line.md
@@ -5,11 +5,10 @@
 DICOMCapacitorService.exe [options]
 ```
 
-## Installation Options
-- `--install`, `-i`: Install as Windows service
+## Service Options
 - `--uninstall`, `-u`: Remove Windows service
 - `--restart-service [PID]`, `-rs [PID]`: Restart service using process ID
-- `--path`: Sets the path to the configuration files (default: `%ProgramData%\Flux\DICOM Capacitor\`)
+- `--path`: Sets the path to the configuration files (default: `%ProgramData%\Flux Inc\DICOM Capacitor\`)
 
 ## Configuration Options
 - `--activation-code [CODE]`, `-a [CODE]`: Set product activation code
@@ -26,16 +25,6 @@ DICOMCapacitorService.exe [options]
 - `--quit`, `-q`: Exit after running commands
 
 ## Examples
-
-### Basic Installation
-```bash
-DICOMCapacitorService.exe --install
-```
-
-### Custom Installation
-```bash
-DICOMCapacitorService.exe --install --path "D:\DICOM" --no-storage-scu --save-config
-```
 
 ### Set Activation
 ```bash

--- a/docs/dicom-capacitor/installation.md
+++ b/docs/dicom-capacitor/installation.md
@@ -8,43 +8,27 @@
 - 1 GB of free disk space
 - 2 GHz or faster, x64 or arm64, processor
 
-## Windows Installation
+## Installation
 
-1. Download the latest version of DICOM Capacitor from the [Flux Website](#)
+1. Download the latest version of DICOM Capacitor from the [Flux Website](https://store.fluxinc.ca/files)
 2. Run the installer
 3. Open your Services MMC and start and stop the DICOM Capacitor service
-4. Open the `%ProgramData%\Flux\DICOM Capacitor\` folder, which contains the following files
+4. Open the `%ProgramData%\Flux Inc\DICOM Capacitor\` folder, which contains the following files
     - `cache/` - Contains the cache of DICOM data
     - `log/` - Contains the logs for DICOM Capacitor
         - `capacitor_service.log` - Contains the main log for DICOM Capacitor
     - `nodes.yml` - Specifies the nodes that DICOM Capacitor will use to send and receive DICOM data
     - `config.yml` - Specifies the settings for DICOM Capacitor
 
-
-## Command Line Installation
-Install DICOM Capacitor as a Windows service:
+You can override the default location using the path option:
 ```bash
-DICOMCapacitorService.exe --install
+DICOMCapacitorService --path /custom/path
 ```
 
-### Custom Path Installation 
-Install with a specific base directory:
-```bash
-DICOMCapacitorService.exe --install --path "C:\CustomPath\DICOMCapacitor"
-```
+## Configuration
+The service configuration is stored in the `config.yml` file.
 
-### Uninstall Service
-Remove the Windows service:
-```bash
-DICOMCapacitorService.exe --uninstall
-```
-For more options, see [Command Line Options](/dicom-capacitor/command-line.md)
 ## Service Management
-
-### Windows Service Controls
-- Start: `net start DICOMCapacitorService`
-- Stop: `net stop DICOMCapacitorService`
-- Restart: `DICOMCapacitorService.exe --restart-service [ProcessID]`
 
 ### Service Components
 During startup, the service initializes:
@@ -53,24 +37,18 @@ During startup, the service initializes:
 - Query/Retrieve SCP
 - Storage Commitment SCP
 
-### Initial Configuration
-Configure core service behavior during installation:
+### Service Configuration
+Configure core service behavior from the command line:
 ```bash
 # Disable Storage SCU
-DICOMCapacitorService.exe --install --no-storage-scu
+DICOMCapacitorService.exe --no-storage-scu
 
 # Disable Worklist SCU
-DICOMCapacitorService.exe --install --no-worklist-scu
+DICOMCapacitorService.exe --no-worklist-scu
 
 # Disable file preparation
-DICOMCapacitorService.exe --install --no-prepare
+DICOMCapacitorService.exe --no-prepare
 ```
-
-## Development Mode
-Run in interactive console mode for testing:
-1. Launch without installation flags
-2. Service runs with console output
-3. Press any key to terminate
 
 ## Logging
 - Service logs: `[LogPath]/capacitor_service.log`
@@ -81,7 +59,6 @@ Monitor service health through:
 - Windows Event Viewer
 - Service status in Windows Services
 - Log files in configured log directory
-
 
 ## Docker Installation
 

--- a/docs/dicom-capacitor/installation.md
+++ b/docs/dicom-capacitor/installation.md
@@ -20,6 +20,69 @@
     - `nodes.yml` - Specifies the nodes that DICOM Capacitor will use to send and receive DICOM data
     - `config.yml` - Specifies the settings for DICOM Capacitor
 
+
+## Command Line Installation
+Install DICOM Capacitor as a Windows service:
+```bash
+DICOMCapacitorService.exe --install
+```
+
+### Custom Path Installation 
+Install with a specific base directory:
+```bash
+DICOMCapacitorService.exe --install --path "C:\CustomPath\DICOMCapacitor"
+```
+
+### Uninstall Service
+Remove the Windows service:
+```bash
+DICOMCapacitorService.exe --uninstall
+```
+For more options, see [Command Line Options](/dicom-capacitor/command-line.md)
+## Service Management
+
+### Windows Service Controls
+- Start: `net start DICOMCapacitorService`
+- Stop: `net stop DICOMCapacitorService`
+- Restart: `DICOMCapacitorService.exe --restart-service [ProcessID]`
+
+### Service Components
+During startup, the service initializes:
+- Storage SCP (DICOM storage provider)
+- Worklist SCP (DICOM worklist provider)
+- Query/Retrieve SCP
+- Storage Commitment SCP
+
+### Initial Configuration
+Configure core service behavior during installation:
+```bash
+# Disable Storage SCU
+DICOMCapacitorService.exe --install --no-storage-scu
+
+# Disable Worklist SCU
+DICOMCapacitorService.exe --install --no-worklist-scu
+
+# Disable file preparation
+DICOMCapacitorService.exe --install --no-prepare
+```
+
+## Development Mode
+Run in interactive console mode for testing:
+1. Launch without installation flags
+2. Service runs with console output
+3. Press any key to terminate
+
+## Logging
+- Service logs: `[LogPath]/capacitor_service.log`
+- Audit logs: `[LogPath]/capacitor_service_audit.log`
+
+## Service Status Monitoring
+Monitor service health through:
+- Windows Event Viewer
+- Service status in Windows Services
+- Log files in configured log directory
+
+
 ## Docker Installation
 
 Refer to the [Docker Operations](/dicom-capacitor/docker) page for instructions on how to run DICOM Capacitor in a Docker container.


### PR DESCRIPTION
- Added a new GitHub workflow for automatically drafting PR descriptions using the `fluxinc/gpt-auto-pr-description-action`.
- Updated the documentation sidebar to rename "Command Line" to "Command Line Options".
- Expanded and restructured the command line options documentation to include:
  - Basic syntax for running the DICOM Capacitor service.
  - Detailed description of service options, including how to uninstall, restart, and set the configuration path.
  - Configuration options with examples, such as setting the activation code and managing secure logs.
  - Development options for applying mutations and clearing logs.
  - Examples demonstrating how to use the command-line options.
- Updated the installation documentation to reflect:
  - The new download link for the latest version of DICOM Capacitor.
  - Instructions on how to override the default installation path.
  - Additional details for service management, including disabling specific service components and how to manage service configurations.
  - Provided information on service logging, including the locations of service and audit logs, as well as instructions for monitoring the service status.