### PR TITLE
DICOM Printer 2: document AutoRotateText action (raster + PDF/ePDF)

### DIFF
--- a/docs/dicom-printer-2/actions/image-manipulation.md
+++ b/docs/dicom-printer-2/actions/image-manipulation.md
@@ -1,13 +1,14 @@
 # Image Manipulation Actions
 
-Image manipulation actions perform transformations on DICOM images, including trimming, rotating, resizing, and adding instances.
+Image manipulation actions perform transformations on DICOM images, including trimming, rotating, auto-orienting, resizing, and adding instances.
 
 ## Image Manipulation Types
 
 DICOM Printer 2 supports the following image manipulation operations:
 
 - **Trim** - Remove pixels from image edges
-- **Rotate** - Rotate image by specified angle
+- **Rotate** - Rotate image by a fixed, specified angle
+- **AutoRotateText** - Automatically orient pages so the dominant parseable text is upright
 - **Resize** - Change image dimensions
 - **AddInstance** - Create additional image instances
 
@@ -335,6 +336,140 @@ Or for a blank canvas:
 
 Either `ImagePath` OR both `Width` and `Height` must be specified.
 
+## AutoRotateText Action
+
+The AutoRotateText action automatically orients each page — **raster image or PDF** — so the **dominant amount of parseable text** is horizontal and upright. Where [Rotate](#rotate-action) applies a fixed angle you choose, AutoRotateText analyzes each page and decides the rotation (0°, 90°, 180°, or 270° clockwise) on its own.
+
+This is intended for mixed-orientation input — for example a landscape graph printed from a browser, where the chart's axis labels are sideways relative to the page while the browser's header, URL, and page number are upright. AutoRotateText weighs the *amount* of text in each orientation (de-weighting page-margin chrome) so the large body of graph text wins over the small amount of header text.
+
+### Safety-first behavior
+
+Because this runs on medical documents, the action is deliberately conservative:
+
+- It **never confidently flips a page upside-down**; a 180° rotation requires a stricter confidence threshold and a minimum amount of text.
+- When the orientation is **ambiguous, it leaves the page unchanged** (a no-op) rather than guess. Pages it cannot confidently orient pass through untouched.
+- It only changes pages when the dominant text axis and direction both clear their confidence gates.
+
+It handles **both raster image pages and direct PDF payloads**, with no difference in the orientation decision between them — a PDF page and its rasterized equivalent are oriented identically:
+
+- **Raster pages** are rotated in place (lossless 90°/180°/270° image transform) and re-saved.
+- **PDF pages** are rotated **losslessly** by adjusting each page's PDF `/Rotate` attribute, so the page is **not rasterized or re-encoded**. The corrected PDF is then stored as an encapsulated PDF (ePDF), which viewers render upright. Each PDF page is rasterized internally only to *analyze* its orientation, never for storage. Per-page rotation is supported, so a multi-page PDF with mixed orientations is corrected page by page.
+
+This works whether PDFs arrive already as PDF payloads or are rasterized to PNGs by [Drop Monitor](../drop-monitor.md) first.
+
+### Basic Syntax
+
+```xml
+<AutoRotateText name="AutoOrient"/>
+```
+
+The defaults are conservative and suitable for most workflows; all elements are optional. A fully specified example:
+
+```xml
+<AutoRotateText name="AutoOrient">
+  <MaxAnalysisSide>1600</MaxAnalysisSide>
+  <MinAxisConfidence>0.30</MinAxisConfidence>
+  <MinScoreDelta>0.15</MinScoreDelta>
+  <MinDirectionConfidence>0.35</MinDirectionConfidence>
+  <MinDirectionConfidence180>0.60</MinDirectionConfidence180>
+  <MinLinesFor180>6</MinLinesFor180>
+  <MarginBandPercent>8</MarginBandPercent>
+  <MarginWeight>0.25</MarginWeight>
+  <TrustHintConfidence>0.90</TrustHintConfidence>
+  <UseHints>true</UseHints>
+  <FailOnUnsupported>false</FailOnUnsupported>
+</AutoRotateText>
+```
+
+**Note:** Error handling (`onError`) is configured on `<Perform>` nodes in the workflow, not on the action definition.
+
+### Elements
+
+All elements are optional. Confidence/weight values are in the range 0–1 unless noted.
+
+| Element | Default | Description |
+|---|---|---|
+| `MaxAnalysisSide` | `1600` | Longest edge (pixels) the page is downsampled to **for analysis only**. The original full-resolution image is what gets rotated. Larger is more accurate but slower. |
+| `MinAxisConfidence` | `0.30` | Minimum confidence that one text axis (horizontal vs. vertical) dominates before any rotation. |
+| `MinScoreDelta` | `0.15` | Minimum normalized margin between the winning and losing axis text scores. |
+| `MinDirectionConfidence` | `0.35` | Minimum confidence in the up-vs-down decision before applying a 90°/270° correction. |
+| `MinDirectionConfidence180` | `0.60` | Stricter confidence required specifically for a 180° flip of an already-horizontal page (the rarest, highest-risk case). |
+| `MinLinesFor180` | `6` | Minimum number of detected text lines required before a 180° flip is allowed. |
+| `MarginBandPercent` | `8` | Width of the page-edge band, as a percentage of the shorter side, whose text is de-weighted (browser headers/footers, URLs, page numbers). Range 0–49. |
+| `MarginWeight` | `0.25` | Weight applied to text inside the margin band. Lower means margin text counts for less toward the orientation decision. |
+| `TrustHintConfidence` | `0.90` | A per-page hint from a Drop Monitor orientation sidecar at or above this confidence is trusted directly, skipping raster analysis. |
+| `UseHints` | `true` | Whether to read the optional `<jobid>.orientation.json` sidecar next to the job. |
+| `FailOnUnsupported` | `false` | When `true`, fail the action on a page it genuinely cannot process (e.g. an unreadable image, or a PDF page when the required QPDF/poppler tools are unavailable). When `false`, log a warning and leave that page unchanged (fail-open). |
+
+#### `<FailOnUnsupported>` (Optional)
+
+Both raster pages and PDF pages are supported. `FailOnUnsupported` controls what happens for a page that genuinely cannot be processed — for example an unreadable image, or a PDF page when the QPDF / poppler tools required for the PDF path are not installed. With `false` (the default) the page is left unchanged and a warning is logged (fail-open); with `true` the action fails.
+
+#### PDF tooling
+
+The PDF path uses two bundled command-line tools, discovered from an environment override, the packaged install location, a development path, then `PATH` (the same scheme as other DP2 tools):
+
+- **QPDF** — applies the lossless per-page `/Rotate` (already packaged for the `MergeJob` action).
+- **poppler `pdftopng`** — rasterizes each PDF page for *analysis only* (ships with the Drop Monitor component).
+
+If either tool is missing, PDF pages are left unchanged unless `FailOnUnsupported` is `true`. No configuration is needed for normal installs.
+
+### Orientation hints (Drop Monitor)
+
+AutoRotateText can consume an optional per-page orientation sidecar written by Drop Monitor next to the job manifest, named `<jobid>.orientation.json`. Hints are keyed by emitted raster filename and carry the clockwise rotation to apply:
+
+```json
+{
+  "version": 1,
+  "pages": {
+    "1730000000000_0.png": {
+      "recommendedClockwiseDegrees": 90,
+      "confidence": 0.87,
+      "source": "dropmonitor-pdf-raster"
+    }
+  }
+}
+```
+
+A hint at or above `TrustHintConfidence` is applied directly and raster analysis is skipped. Lower-confidence, malformed, or missing hints fall back to the built-in analyzer. Set `UseHints` to `false` to ignore sidecars entirely.
+
+### Examples
+
+#### Drop-in auto-orientation
+
+```xml
+<AutoRotateText name="AutoOrient"/>
+```
+
+```xml
+<Workflow>
+  <Perform action="AutoOrient"/>
+  <Perform action="SendToPACS"/>
+</Workflow>
+```
+
+Place `AutoRotateText` **before** any action that consumes the page images (Store, Print, Save) so downstream steps see the corrected orientation.
+
+#### Stronger margin de-weighting for browser-printed pages
+
+Browser printouts often carry a header, URL, and page number that you never want to drive orientation. Lowering `MarginWeight` makes that chrome count for even less:
+
+```xml
+<AutoRotateText name="AutoOrientBrowser">
+  <MarginWeight>0.05</MarginWeight>
+</AutoRotateText>
+```
+
+#### Disable 180° flips entirely
+
+If you only want landscape↔portrait correction and never an upside-down flip, raise the 180° gate so it never triggers:
+
+```xml
+<AutoRotateText name="AutoOrientNo180">
+  <MinDirectionConfidence180>1.0</MinDirectionConfidence180>
+</AutoRotateText>
+```
+
 ## Combining Image Manipulations
 
 Multiple image manipulations can be performed in sequence:
@@ -440,6 +575,8 @@ Multiple image manipulations can be performed in sequence:
 
 ### Correct Orientation
 
+When every page needs the *same* fixed correction, use `Rotate` gated on a tag:
+
 ```xml
 <Actions>
   <!-- Rotate landscape documents to portrait -->
@@ -457,12 +594,26 @@ Multiple image manipulations can be performed in sequence:
 </Workflow>
 ```
 
+When pages arrive in **mixed** orientations (some landscape, some portrait, some upside-down), let [AutoRotateText](#autorotatetext-action) decide per page instead of branching on aspect ratio:
+
+```xml
+<Actions>
+  <AutoRotateText name="AutoOrient"/>
+</Actions>
+
+<Workflow>
+  <Perform action="AutoOrient"/>
+  <Perform action="SendToPACS"/>
+</Workflow>
+```
+
 ## Performance Considerations
 
 Image manipulation operations can be CPU and memory intensive:
 
 - **Trim** - Fast operation, minimal CPU usage
 - **Rotate** - Moderate CPU usage, especially for large images
+- **AutoRotateText** - Moderate CPU usage: each page is downsampled to `MaxAnalysisSide` for analysis (lower it to trade accuracy for speed), and only pages that pass the confidence gates are actually rotated. Ambiguous pages are a fast no-op.
 - **Resize** - CPU usage depends on scaling algorithm and size change
 - **AddInstance** - Fast to moderate CPU usage depending on:
   - Image file loading (if `<ImagePath>` specified)

--- a/docs/dicom-printer-2/actions/index.md
+++ b/docs/dicom-printer-2/actions/index.md
@@ -34,6 +34,7 @@ DICOM Printer 2 supports the following action types:
 ### Image Processing Actions
 
 - **[Image Manipulation](image-manipulation.md)** - Trim, rotate, resize images
+- **[AutoRotateText](image-manipulation.md#autorotatetext-action)** - Automatically orient pages so the dominant parseable text is upright (conservative; no-ops when ambiguous)
 - **[AddInstance](image-manipulation.md#addinstance)** - Adds a new image instance to the job from an image file or blank canvas
 
 ### Integration Actions

--- a/docs/dicom-printer-2/config.md
+++ b/docs/dicom-printer-2/config.md
@@ -754,6 +754,26 @@ See section: Connection Parameters.
   - `<Angle>`: The number of degrees by which the images will be rotated clockwise. Must be an integer value divisible by 90.
 - **Default Value**: Not applicable.
 
+### Subsection: `<AutoRotateText>`
+
+- **Description**: Automatically orients each page so the dominant amount of *parseable text* is horizontal and upright, rotating clockwise by 0, 90, 180, or 270 degrees. Unlike `<Rotate>` (which applies a fixed angle), `AutoRotateText` analyzes each page and chooses the rotation. It handles **both raster image pages and direct PDF pages** with the same decision: raster pages are rotated in place, while PDF pages are rotated losslessly via the page `/Rotate` attribute (no rasterizing or re-encoding) and stored as encapsulated PDF (ePDF). It is deliberately conservative: when the orientation is ambiguous it leaves the page unchanged rather than risk an upside-down result. Normal usage needs no child elements — just `<AutoRotateText name="AutoOrient"/>`. See the [AutoRotateText action reference](/dicom-printer-2/actions/image-manipulation#autorotatetext-action) for full guidance.
+- **Occurrence**: Zero or more.
+- **Attributes**:
+  - `name` : a unique identifier by which this action can be referred to by other entities.
+- **Content** (all optional; conservative defaults shown):
+  - `<MaxAnalysisSide>`: Longest edge, in pixels, the page is downsampled to for analysis. The full-resolution image is what gets rotated. Default `1600`.
+  - `<MinAxisConfidence>`: Minimum confidence that one text axis (horizontal vs. vertical) dominates before any rotation. Range 0–1. Default `0.30`.
+  - `<MinScoreDelta>`: Minimum normalized margin between the winning and losing axis text scores. Range 0–1. Default `0.15`.
+  - `<MinDirectionConfidence>`: Minimum confidence in the up-vs-down decision before applying a 90°/270° correction. Range 0–1. Default `0.35`.
+  - `<MinDirectionConfidence180>`: Stricter direction confidence required specifically for a 180° flip of an already-horizontal page (the rarest, highest-risk case). Range 0–1. Default `0.60`.
+  - `<MinLinesFor180>`: Minimum number of detected text lines required before a 180° flip is allowed. Default `6`.
+  - `<MarginBandPercent>`: Width of the page-edge band, as a percentage of the shorter side, whose text is de-weighted (e.g. browser headers/footers, URLs, page numbers). Range 0–49. Default `8`.
+  - `<MarginWeight>`: Weight applied to text that falls inside the margin band. Range 0–1; lower means margin text counts for less. Default `0.25`.
+  - `<TrustHintConfidence>`: A per-page orientation hint from Drop Monitor (`<jobid>.orientation.json`) at or above this confidence is trusted directly, skipping raster analysis. Range 0–1. Default `0.90`.
+  - `<UseHints>`: Whether to read the optional Drop Monitor orientation sidecar. `true` or `false`. Default `true`.
+  - `<FailOnUnsupported>`: When `true`, the action fails on a page it genuinely cannot process (e.g. an unreadable image, or a PDF page when the required QPDF/poppler tools are unavailable); when `false` it logs a warning and leaves that page unchanged (fail-open). Default `false`.
+- **Default Value**: Not applicable.
+
 ### Subsection: `<SetTag>`
 
 - **Description**: Assigns a specified value to a DICOM tag. This action can set both standard and private DICOM tags, with options to control replacement behavior and whether the tag is applied globally to the job or uniquely to each image instance.

--- a/docs/dicom-printer-2/configuration.md
+++ b/docs/dicom-printer-2/configuration.md
@@ -36,7 +36,7 @@ Actions define the processing steps that are applied to each print job or file. 
 - **[SetTag](actions/settag.md)** - Add, modify, or delete DICOM tags
 - **[SetSequence](actions/setsequence.md)** - Write DICOM sequence structures into the job dataset
 - **[Save](actions/save.md)** - Save DICOM files to local directories
-- **[Image Manipulation](actions/image-manipulation.md)** - Trim, rotate, or resize images
+- **[Image Manipulation](actions/image-manipulation.md)** - Trim, rotate, auto-orient, or resize images
 - **[Run (Plugins)](actions/run.md)** - Execute external console or GUI applications
 - **[Notify](actions/notify.md)** - Send notifications
 


### PR DESCRIPTION
Documents the new `AutoRotateText` workflow action for DICOM Printer 2 (implemented in fluxinc/dicom-printer-2#151 / PR #153).

AutoRotateText automatically orients pages so the dominant parseable text is horizontal and upright, covering **both raster image pages and direct PDF pages** (PDF pages are rotated losslessly via the page `/Rotate` attribute and stored as ePDF). It is conservative by default — ambiguous pages are left unchanged — and normal usage needs no settings: `<AutoRotateText name="AutoOrient"/>`.

Changes:
- `actions/image-manipulation.md` — full AutoRotateText section (element table, Drop Monitor hint sidecar, PDF tooling, safety-first behavior, examples), plus intro/types-list/use-case cross-references and a performance note.
- `actions/index.md`, `configuration.md` — action lists updated.
- `config.md` — full `<AutoRotateText>` configuration-reference subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)